### PR TITLE
Make PushMetrics a subclass of Milemarker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 0.9.0 - 2023-02-06
+
+- Subclass Milemarker to ensure that PushMetrics will work with the entire
+  Milemarker API
+
+- Use a clever approach to dynamic subclassing to generate PushMetrics classes
+  that subclass a different Milemarker subclass, and allow injecting a
+  different Milemarker implementation for testing. In the future, if we simply
+  the public Milemarker API we may be able to go back to delegating.
+
+## 0.0.1 - 2023-01-27
+
+- Extract PushMarker as a separate gem from
+  https://github.com/hathitrust/holdings-backend
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    push_metrics (0.0.1)
+    push_metrics (0.9.0)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ push gateway after each `batch_size` records and on completion.
 ```ruby
 require 'push_metrics';
 
-batch_size = 1000
-marker = PushMetrics.new(batch_size)
+marker = PushMetrics.new(batch_size: 1000)
 
 File.open(input_file).each do |line|
   do_whatever_needs_doing(line)
@@ -73,12 +72,22 @@ along with its defaults.
 
 ### Configuring `milemarker`
 
-You can pass in your own `milemarker` instance:
+PushMetrics is a subclass of Milemarker, so you can pass in constructor
+arguments for Milemarker as well:
 
 ```ruby
-milemarker = Milemarker.new(logger: my_custom_logger)
-pushmetrics = PushMetrics.new(marker: milemarker)
+pushmetrics = PushMetrics.new(logger: my_custom_logger)
 ```
+
+### Using another Milemarker implementation
+
+If you want to use a different Milemarker (e.g. Milemarker::Structured), you can do that:
+
+```ruby
+pushmetrics = PushMetrics(Milemarker::Structured).new
+```
+
+🤯 thanks to the magic of dynamic class definition in Ruby...
 
 See also [milemarker](https://github.com/hathitrust/milemarker) for additional options and configuration.
 

--- a/push_metrics.gemspec
+++ b/push_metrics.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "push_metrics"
-  spec.version = "0.0.1"
+  spec.version = "0.9.0"
   spec.authors = ["Aaron Elkiss"]
   spec.email = ["aelkiss@umich.edu"]
 


### PR DESCRIPTION
As written, the documentation was incorrect - because PushMarker delegated rather than subclassed, it meant that calling methods that are part of the public Milemarker interface but that are not defined in PushMarker did not use the PushMarker implementation. I think in this case that subclassing is more appropriate than delegation, but it makes some of the tests harder (e.g. we can't easily mock the number of records or test directly that it actually calls superclass methods). Still, all lines are covered, and this is probably good enough.