### PR TITLE
TTO-145 PushMetrics should not throw exception if pushgateway cannot …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    push_metrics (0.9.0)
+    push_metrics (0.9.1)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 
@@ -77,6 +77,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/push_metrics.rb
+++ b/lib/push_metrics.rb
@@ -61,7 +61,15 @@ def PushMetrics(superclass)
       duration_metric.set(total_seconds_so_far)
       records_processed_metric.set(count)
 
-      pushgateway.add(registry)
+      begin
+        pushgateway.add(registry)
+      rescue => e
+        if logger
+          logger.error(e.to_s)
+        else
+          raise
+        end
+      end
     end
 
     def duration_metric

--- a/lib/push_metrics.rb
+++ b/lib/push_metrics.rb
@@ -64,11 +64,7 @@ def PushMetrics(superclass)
       begin
         pushgateway.add(registry)
       rescue => e
-        if logger
-          logger.error(e.to_s)
-        else
-          raise
-        end
+        logger&.error(e.to_s)
       end
     end
 

--- a/push_metrics.gemspec
+++ b/push_metrics.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "push_metrics"
-  spec.version = "0.9.0"
+  spec.version = "0.9.1"
   spec.authors = ["Aaron Elkiss"]
   spec.email = ["aelkiss@umich.edu"]
 

--- a/spec/push_metrics_spec.rb
+++ b/spec/push_metrics_spec.rb
@@ -212,6 +212,34 @@ RSpec.describe PushMetrics do
       expect(metrics).to match(/^job_last_success\S* \S+/m)
     end
   end
+
+  describe "error handling" do
+    let(:pm_endpoint) { "http://pushgateway.invalid:9091" }
+
+    context "with a logger" do
+      let(:logger) { instance_double Logger, error: nil }
+      let(:pm_marker) {
+        PushMetrics.new(batch_size: batch_size, registry: Prometheus::Client::Registry.new,
+          pushgateway_endpoint: pm_endpoint, logger: logger)
+      }
+
+      it "logs exception" do
+        expect(logger).to receive(:error)
+        pm_marker
+      end
+    end
+
+    context "without a logger" do
+      let(:pm_marker) {
+        PushMetrics.new(batch_size: batch_size, registry: Prometheus::Client::Registry.new,
+          pushgateway_endpoint: pm_endpoint)
+      }
+
+      it "raises StandardError" do
+        expect { pm_marker }.to raise_error(StandardError)
+      end
+    end
+  end
 end
 
 RSpec.describe "PushMetric varieties" do

--- a/spec/push_metrics_spec.rb
+++ b/spec/push_metrics_spec.rb
@@ -235,8 +235,8 @@ RSpec.describe PushMetrics do
           pushgateway_endpoint: pm_endpoint)
       }
 
-      it "raises StandardError" do
-        expect { pm_marker }.to raise_error(StandardError)
+      it "does not raise error" do
+        expect { pm_marker }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
…be reached

- Logs but does not bail out if `add` calls to pushgateway raise StandardError.
- If no logger is configured, any such errors will be swallowed. 