### PR TITLE
Addresses #7 Use JOB_NAMESPACE for instance label when provided

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    push_metrics (0.9.1)
+    push_metrics (0.9.2)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 
@@ -10,6 +10,7 @@ GEM
   specs:
     ast (2.4.2)
     base64 (0.2.0)
+    climate_control (1.2.0)
     coderay (1.1.3)
     diff-lcs (1.5.1)
     docile (1.4.1)
@@ -96,11 +97,13 @@ GEM
     uri (1.0.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.0)
+  climate_control
   faraday (~> 2.7)
   pry
   push_metrics!

--- a/lib/push_metrics.rb
+++ b/lib/push_metrics.rb
@@ -24,7 +24,12 @@ def PushMetrics(superclass)
       job_name: File.basename($PROGRAM_NAME),
       pushgateway_endpoint: ENV["PUSHGATEWAY"] || "http://localhost:9091",
       success_interval: ENV["JOB_SUCCESS_INTERVAL"],
-      pushgateway: Prometheus::Client::Push.new(job: job_name, gateway: pushgateway_endpoint),
+      instance: ENV["JOB_NAMESPACE"],
+      pushgateway: Prometheus::Client::Push.new(
+        job: job_name,
+        gateway: pushgateway_endpoint,
+        grouping_key: {instance: instance}
+      ),
       **kwargs
     )
       super(**kwargs)

--- a/push_metrics.gemspec
+++ b/push_metrics.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "push_metrics"
-  spec.version = "0.9.1"
+  spec.version = "0.9.2"
   spec.authors = ["Aaron Elkiss"]
   spec.email = ["aelkiss@umich.edu"]
 
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "prometheus-client", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~>2.0"
+  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~>13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/push_metrics.gemspec
+++ b/push_metrics.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "push_metrics"
-  spec.version = "0.9.2"
+  spec.version = "0.10.0"
   spec.authors = ["Aaron Elkiss"]
   spec.email = ["aelkiss@umich.edu"]
 


### PR DESCRIPTION
- Use `grouping_key` based on keyword argument `instance` defaulting to `JOB_NAMESPACE`
- Use `ClimateControl` in tests
- Version bump to 0.9.2

Note: does not address #8 which I assume is a "do soon but not right now"?