### PR TITLE
Dependency matrix update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,7 @@ jobs:
   # Run tests
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [3.2, 3.3, 3.4, 4.0, jruby]
+
     steps:
       - uses: actions/checkout@v6
 
@@ -21,12 +19,6 @@ jobs:
         run: |
           docker compose build
           docker compose run test bundle install
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
 
       - name: Run standardrb
         run: docker compose run test bundle exec standardrb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,22 @@ jobs:
   # Run tests
   test:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        ruby: [3.2, 3.3, 3.4, 4.0, jruby]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up tests
         run: |
           docker compose build
           docker compose run test bundle install
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
       - name: Run standardrb
         run: docker compose run test bundle exec standardrb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3 AS base
+FROM ruby:4.0 AS base
 
 ARG UNAME=app
 ARG UID=1000

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-22
   x86_64-linux
+  universal-java-21
 
 DEPENDENCIES
   bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,6 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-22
   x86_64-linux
-  universal-java-21
 
 DEPENDENCIES
   bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,100 +1,125 @@
 PATH
   remote: .
   specs:
-    push_metrics (0.9.2)
+    push_metrics (0.10.1)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
-    base64 (0.2.0)
+    ast (2.4.3)
+    base64 (0.3.0)
     climate_control (1.2.0)
-    coderay (1.1.3)
-    diff-lcs (1.5.1)
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.12.2)
+    erb (6.0.3)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
-    json (2.9.1)
-    language_server-protocol (3.17.0.3)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    io-console (0.8.2)
+    irb (1.17.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.19.4)
+    language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    logger (1.6.5)
-    method_source (1.1.0)
-    milemarker (1.0.0)
-    net-http (0.6.0)
-      uri
-    parallel (1.26.3)
-    parser (3.3.6.0)
+    logger (1.7.0)
+    milemarker (1.0.2)
+      logger
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    parallel (1.28.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    prometheus-client (4.2.3)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    prometheus-client (4.2.5)
       base64
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
+    psych (5.3.1)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
-    regexp_parser (2.10.0)
-    rspec (3.13.0)
+    rake (13.4.2)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.2)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.2)
-    rubocop (1.69.2)
+    rspec-support (3.13.7)
+    rubocop (1.84.2)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.36.2, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.37.0)
-      parser (>= 3.3.1.0)
-    rubocop-performance (1.23.1)
-      rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.1)
-    simplecov-lcov (0.8.0)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
-    standard (1.43.0)
+    standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.69.1)
+      rubocop (~> 1.84.0)
       standard-custom (~> 1.0.0)
-      standard-performance (~> 1.6)
+      standard-performance (~> 1.8)
     standard-custom (1.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.50)
-    standard-performance (1.6.0)
+    standard-performance (1.9.0)
       lint_roller (~> 1.1)
-      rubocop-performance (~> 1.23.0)
+      rubocop-performance (~> 1.26.0)
     standardrb (1.0.1)
       standard
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
-    uri (1.0.2)
+    stringio (3.2.0)
+    tsort (0.2.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
 
 PLATFORMS
   aarch64-linux
@@ -102,10 +127,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler
   climate_control
+  debug
   faraday (~> 2.7)
-  pry
   push_metrics!
   rake (~> 13.0)
   rspec (~> 3.0)
@@ -114,4 +139,4 @@ DEPENDENCIES
   standardrb
 
 BUNDLED WITH
-   2.6.2
+  4.0.10

--- a/push_metrics.gemspec
+++ b/push_metrics.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "push_metrics"
-  spec.version = "0.10.0"
+  spec.version = "0.10.1"
   spec.authors = ["Aaron Elkiss"]
   spec.email = ["aelkiss@umich.edu"]
 
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "milemarker", "~> 1.0"
   spec.add_dependency "prometheus-client", "~> 4.0"
 
-  spec.add_development_dependency "bundler", "~>2.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "debug"
   spec.add_development_dependency "rake", "~>13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "standardrb"


### PR DESCRIPTION
 - Use Ruby 4 under Docker
 - Unpin bundler and allow update to 4.0
 - `bundle update --all`
